### PR TITLE
chore(KFLUXVNGD-43): add tekton-results

### DIFF
--- a/argo-cd-apps/dependencies/kustomization.yaml
+++ b/argo-cd-apps/dependencies/kustomization.yaml
@@ -2,9 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cert-manager
+  - trust-manager  
   - cluster-issuer
   - tekton-operator
   - tekton-config
+  - tekton-results  
   - pipelines-as-code
   - keycloak
-  - trust-manager

--- a/argo-cd-apps/dependencies/tekton-results/kustomization.yml
+++ b/argo-cd-apps/dependencies/tekton-results/kustomization.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tekton-results.yaml

--- a/argo-cd-apps/dependencies/tekton-results/tekton-results.yaml
+++ b/argo-cd-apps/dependencies/tekton-results/tekton-results.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tekton-results
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/tekton-results
+          environment: staging
+          clusterDir: ""
+  template:
+    metadata:
+      name: tekton-results-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/konflux-ci/infra-deployments.git
+        targetRevision: main
+      destination:
+        server: '{{server}}'
+      syncPolicy:
+        automated: 
+          prune: true
+          selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/environments/production/kustomization.yaml
+++ b/argo-cd-apps/environments/production/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../dependencies/pipelines-as-code  
   - ../../dependencies/tekton-config
   - ../../dependencies/tekton-operator
+  - ../../dependencies/tekton-results  
   - ../../dependencies/trust-manager
   - ../../konflux-ci/application-api
   - ../../konflux-ci/build-service
@@ -14,7 +15,6 @@ resources:
   - ../../konflux-ci/integration
   - ../../konflux-ci/rbac
   - ../../konflux-ci/release
-  - ../../konflux-ci/ui  
 namespace: argocd
 
 patches:

--- a/argo-cd-apps/environments/staging/kustomization.yaml
+++ b/argo-cd-apps/environments/staging/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../dependencies/keycloak
   - ../../dependencies/pipelines-as-code  
   - ../../dependencies/tekton-config
+  - ../../dependencies/tekton-results  
   - ../../dependencies/tekton-operator
   - ../../dependencies/trust-manager  
   - ../../konflux-ci/application-api
@@ -14,7 +15,6 @@ resources:
   - ../../konflux-ci/integration
   - ../../konflux-ci/rbac
   - ../../konflux-ci/release
-  - ../../konflux-ci/ui
 namespace: argocd
 
 patches:

--- a/components/tekton-results/base/kustomization.yml
+++ b/components/tekton-results/base/kustomization.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/konflux-ci/konflux-ci/dependencies/tekton-results?ref=fa491580946a7ae5feac06d6a345248f1787a313
+
+patches:
+  - patch: |
+       - op: add
+         path: /spec/template/spec/initContainers
+         value:
+          - name: volume-permissions
+            image: busybox
+            command: ['sh', '-c', 'chown -R 1001:1001 /bitnami']
+            volumeMounts:
+            - name: postgredb
+              mountPath: /bitnami/postgresql
+    target:
+      kind: StatefulSet
+      name: tekton-results-postgres              

--- a/components/tekton-results/production/kustomization.yaml
+++ b/components/tekton-results/production/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/components/tekton-results/staging/kustomization.yaml
+++ b/components/tekton-results/staging/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/deploy-argocd.sh
+++ b/deploy-argocd.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-
+set -ex
 # Deploy Applications to ArgoCD on EKS Cluster
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"


### PR DESCRIPTION
- add patch for `bitnami` permissions on `tekton-results`
- add `tekton-results`
- removing `ui` component because of errors in argo

results of argocd deployment can be seen in https://argocd.konflux-ci.net/applications?showFavorites=false&proj=&sync=&autoSync=&health=&namespace=&cluster=&labels=&page=0 (currently pointing to my repo)