### PR TITLE
Remove customizations from tektonconfig deployments

### DIFF
--- a/components/tekton-config/base/kustomization.yml
+++ b/components/tekton-config/base/kustomization.yml
@@ -3,3 +3,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/konflux-ci/konflux-ci/dependencies/tekton-config?ref=6a391f0da1c12680bf5a0b2cc534cdd8cfa6fcea
+
+patches:
+  - patch: |
+      - op: remove
+        path: /spec/chain/options
+    target:
+      kind: TektonConfig
+      name: config
+  - patch: |
+      - op: remove
+        path: /spec/pipeline/options
+    target:
+      kind: TektonConfig
+      name: config


### PR DESCRIPTION
konflux-ci customizes the Tekton operator deployments through tektonconfig changes in order to mount custom CA certificates. This is causing issues here, and we don't need it, so removing it.